### PR TITLE
Deploy to Bluemix

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,0 +1,9 @@
+.project
+.jshintrc
+.settings
+app/bower_components
+.tern-project
+node_modules
+npm-debug.log
+.strong-pm/env.json
+development/vcaps.properties

--- a/README.md
+++ b/README.md
@@ -25,3 +25,11 @@ Complete these steps first if you have not already:
 Create a Cloudant service within Bluemix if one has not already been created:
 
     $ cf create-service cloudantNoSQLDB Shared pipes-cloudant-service
+
+### Deploying
+
+To deploy to Bluemix, simply:
+
+    $ cf push
+
+**Note:** You may notice that Bluemix assigns a URL to your application containing a random word. This is defined in the `manifest.yml` file where the `random-route` key set to the value of `true`. This ensures that multiple people deploying this application to Bluemix do not run into naming collisions. To specify your own route, remove the `random-route` line from the `manifest.yml` file and add a `host` key with the unique value you would like to use for the host name.

--- a/README.md
+++ b/README.md
@@ -45,3 +45,24 @@ To deploy to Bluemix, simply:
     $ cf push
 
 **Note:** You may notice that Bluemix assigns a URL to your application containing a random word. This is defined in the `manifest.yml` file where the `random-route` key set to the value of `true`. This ensures that multiple people deploying this application to Bluemix do not run into naming collisions. To specify your own route, remove the `random-route` line from the `manifest.yml` file and add a `host` key with the unique value you would like to use for the host name.
+
+### Privacy Notice
+
+This web application includes code to track deployments to [IBM Bluemix](https://www.bluemix.net/) and other Cloud Foundry platforms. The following information is sent to a [Deployment Tracker](https://github.com/cloudant-labs/deployment-tracker) service on each deployment:
+
+* Application Name (`application_name`)
+* Space ID (`space_id`)
+* Application Version (`application_version`)
+* Application URIs (`application_uris`)
+
+This data is collected from the `VCAP_APPLICATION` environment variable in IBM Bluemix and other Cloud Foundry platforms. This data is used by IBM to track metrics around deployments of sample applications to IBM Bluemix to measure the usefulness of our examples, so that we can continuously improve the content we offer to you. Only deployments of sample applications that include code to ping the Deployment Tracker service will be tracked.
+
+#### Disabling Deployment Tracking
+
+Deployment tracking can be disabled by removing the following line from `server.js`:
+
+```
+require("cf-deployment-tracker-client").track();
+```
+
+Once that line is removed, you may also uninstall the `cf-deployment-tracker-client` npm package.

--- a/README.md
+++ b/README.md
@@ -9,3 +9,5 @@
 
 
 ## Developing
+
+## Deploy to IBM Bluemix

--- a/README.md
+++ b/README.md
@@ -11,3 +11,11 @@
 ## Developing
 
 ## Deploy to IBM Bluemix
+
+### Configuring Cloud Foundry
+
+Complete these steps first if you have not already:
+
+1. [Install the Cloud Foundry command line interface.](https://www.ng.bluemix.net/docs/#starters/install_cli.html)
+2. Follow the instructions at the above link to connect to Bluemix.
+3. Follow the instructions at the above link to log in to Bluemix.

--- a/README.md
+++ b/README.md
@@ -19,3 +19,9 @@ Complete these steps first if you have not already:
 1. [Install the Cloud Foundry command line interface.](https://www.ng.bluemix.net/docs/#starters/install_cli.html)
 2. Follow the instructions at the above link to connect to Bluemix.
 3. Follow the instructions at the above link to log in to Bluemix.
+
+### Creating Backing Services
+
+Create a Cloudant service within Bluemix if one has not already been created:
+
+    $ cf create-service cloudantNoSQLDB Shared pipes-cloudant-service

--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@
 
 ## Deploy to IBM Bluemix
 
+The fastest way to deploy this application to Bluemix is to click the **Deploy to Bluemix** button below. If you prefer instead to deploy manually then read the entirety of this section.
+
+[![Deploy to Bluemix](https://bluemix.net/deploy/button_x2.png)](https://bluemix.net/deploy?repository=https://github.com/ibm-cds-labs/pipes)
+
+**Don't have a Bluemix account?** If you haven't already, you'll be prompted to sign up for a Bluemix account when you click the button.  Sign up, verify your email address, then return here and click the the **Deploy to Bluemix** button again. Your new credentials let you deploy to the platform and also to code online with Bluemix and Git. If you have questions about working in Bluemix, find answers in the [Bluemix Docs](https://www.ng.bluemix.net/docs/).
+
 ### Configuring Cloud Foundry
 
 Complete these steps first if you have not already:

--- a/README.md
+++ b/README.md
@@ -26,6 +26,18 @@ Create a Cloudant service within Bluemix if one has not already been created:
 
     $ cf create-service cloudantNoSQLDB Shared pipes-cloudant-service
 
+Create a dashDB service within Bluemix if one has not already been created:
+
+    $ cf create-service dashDB Entry pipes-dashdb-service
+
+Create a DataWorks service within Bluemix if one has not already been created:
+
+    $ cf create-service DataWorks free pipes-dataworks-service
+
+Create a Single Sign On (SSO) service within Bluemix if one has not already been created:
+
+    $ cf create-service SingleSignOn standard pipes-sso-service
+
 ### Deploying
 
 To deploy to Bluemix, simply:

--- a/manifest.yml
+++ b/manifest.yml
@@ -8,3 +8,5 @@ applications:
   disk_quota: 1024M
   command: node --expose-gc server.js
   path: .
+  services:
+  - pipes-cloudant-service

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,4 +1,8 @@
 ---
+declared-services:
+  pipes-cloudant-service:
+    label: cloudantNoSQLDB
+    plan: Shared
 applications:
 - name: pipes
   memory: 512M

--- a/manifest.yml
+++ b/manifest.yml
@@ -3,8 +3,8 @@ applications:
 - name: pipes
   memory: 512M
   instances: 1
-  host: pipes
   domain: mybluemix.net
+  random-route: true
   disk_quota: 1024M
   command: node --expose-gc server.js
   path: .

--- a/manifest.yml
+++ b/manifest.yml
@@ -3,6 +3,15 @@ declared-services:
   pipes-cloudant-service:
     label: cloudantNoSQLDB
     plan: Shared
+  pipes-dashdb-service:
+    label: dashDB
+    plan: Entry
+  pipes-dataworks-service:
+    label: DataWorks
+    plan: free
+  pipes-sso-service:
+    label: SingleSignOn
+    plan: standard
 applications:
 - name: pipes
   memory: 512M
@@ -14,3 +23,6 @@ applications:
   path: .
   services:
   - pipes-cloudant-service
+  - pipes-dashdb-service
+  - pipes-dataworks-service
+  - pipes-sso-service

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "async": "^1.2.1",
     "body-parser": "^1.11.0",
     "bower": "^1.4.1",
+    "cf-deployment-tracker-client": "0.0.7",
     "cfenv": "*",
     "cloudant": "^1.0.0",
     "colors": "*",

--- a/package.json
+++ b/package.json
@@ -15,25 +15,26 @@
     "Data Movement"
   ],
   "dependencies": {
-        "express": "^4.10.6",
-        "cloudant": "^1.0.0",
-        "body-parser": "^1.11.0",
-        "errorhandler": "~1.3.6",
-        "lodash": "~3.9.3",
-        "async": "^1.2.1",
-        "cfenv": "*",
-        "jsforce": "^1.4.1",
-        "morgan": "^1.6.0",
-        "when": "~3.7.3",
-        "moment": "^2.10.3",
-        "jsonfile": "^2.2.1",
-        "request": "~2.58.0",
-        "colors": "*"
-   },
-   "devDependencies": {
-        "mocha": "*",
-        "http-proxy": "*"
-    },
+    "async": "^1.2.1",
+    "body-parser": "^1.11.0",
+    "bower": "^1.4.1",
+    "cfenv": "*",
+    "cloudant": "^1.0.0",
+    "colors": "*",
+    "errorhandler": "~1.3.6",
+    "express": "^4.10.6",
+    "jsforce": "^1.4.1",
+    "jsonfile": "^2.2.1",
+    "lodash": "~3.9.3",
+    "moment": "^2.10.3",
+    "morgan": "^1.6.0",
+    "request": "~2.58.0",
+    "when": "~3.7.3"
+  },
+  "devDependencies": {
+    "mocha": "*",
+    "http-proxy": "*"
+  },
   "author": "david_taieb@us.ibm.com",
   "license": "IBM",
   "readmeFilename": "README.md"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Tool for moving data to the cloud: e.g. Salesforce to Cloud",
   "main": "server.js",
   "scripts": {
-  	"postinstall2": "bower cache clean && bower install"
+    "postinstall": "./node_modules/bower/bin/bower cache clean && bower install"
   },
   "repository": "https://github.com/ibm-cds-labs/pipes",
   "keywords": [

--- a/server.js
+++ b/server.js
@@ -70,3 +70,5 @@ if (process.env.VCAP_APP_HOST){
 	global.appPort = port;
 	require('https').createServer(options, app).listen(port,connected);
 }
+
+require("cf-deployment-tracker-client").track();


### PR DESCRIPTION
This pull request makes this application deployable to IBM Bluemix using either a "Deploy to Bluemix" button or manually. The following changes are included:
- A random route is used rather than specifying the host name (prevents naming collisions)
- A "Deploy to Bluemix" section has been added to the README which includes the following sections
  - "Configuring Cloud Foundry"
  - "Creating Backing Services" (includes instructions for creating the Cloudant, dashDB, DataWorks, and SSO services)
  - "Deploying"
- Cloudant, dashDB, DataWorks, and SSO are added as declared services (enables the "Deploy to Bluemix" button to work)
- The Cloudant, dashDB, DataWorks, and SSO services are bound to the application
- A `.cfignore` file has been created which ignores the same files as `.gitignore`
- Bower is installed locally into the application in order to enable running Bower clean and install on npm post install
- Deployments are tracked to the Deployment Tracker service (privacy notice added to README)
- A "Deploy to Bluemix" button has been added to the README

I recommend deleting this application (including its services) and recreating it in Bluemix after merging this pull request in order to bind the backing services properly.
