### PR TITLE
i63: concurrent pipe run issues

### DIFF
--- a/server/pipeRunStats.js
+++ b/server/pipeRunStats.js
@@ -97,7 +97,8 @@ function pipeRunStats(pipe, steps, callback){
 		
 		//Set the current run to this
 		if ( global.currentRun ){
-			var msg = require.util( "A run is already in progress %s", global.currentRun._id );
+			// i63
+			var msg = require("util").format("A run is already in progress %s", global.currentRun._id );
 			logger.error( msg );
 			return callback( msg );
 		}


### PR DESCRIPTION
In some environments the UI does not prevent the user from starting a run while another run is in progress. This change adds additional checks in the back-end to prevent fatal runtime errors.
