### PR TITLE
i55: add connectorID to run document

### DIFF
--- a/server/pipeRunStats.js
+++ b/server/pipeRunStats.js
@@ -19,6 +19,7 @@ function pipeRunStats(pipe, steps, callback){
 	var logger = this.logger = global.getLogger("pipesRun");
 	var runDoc = this.runDoc = {
 		type : "run",
+		connectorId : pipe.connectorId,
 		startTime : moment(),
 		pipeId: pipe._id,
 		status: "NOT_STARTED",


### PR DESCRIPTION
Run documents now include the connectorId property, which identifies the connector that processed the run: 
"_id": "faaabbd6cfb5d9419dc902ad4eed7e86",
  "_rev": "16-1ddda4ba3ebbef235a6c62b8339fe9e6",
  "type": "run",
  **"connectorId": "stripe",**
  "startTime": "2015-10-24T00:10:27.987Z",
  "pipeId": "8961ba79c2c82126183e1fe04c94d682",
...
