### PR TITLE
i75 dataworks service cannot be used

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Create a dashDB service within Bluemix if one has not already been created:
 
 Create a DataWorks service within Bluemix if one has not already been created:
 
-    $ cf create-service DataWorks free pipes-dataworks-service
+    $ cf create-service DataWorks_Gen3 Starter pipes-dataworks-service
 
 Create a Single Sign On (SSO) service within Bluemix if one has not already been created:
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -7,8 +7,8 @@ declared-services:
     label: dashDB
     plan: Entry
   pipes-dataworks-service:
-    label: DataWorks
-    plan: free
+    label: DataWorks_Gen3
+    plan: Starter
   pipes-sso-service:
     label: SingleSignOn
     plan: standard


### PR DESCRIPTION
Updated manifest and readme to use the new service label and plan name.
